### PR TITLE
use XPUB, XSUB, zmq.proxy in message_proxy

### DIFF
--- a/message_proxy.py
+++ b/message_proxy.py
@@ -1,5 +1,4 @@
 # http://zguide.zeromq.org/page:all#The-Dynamic-Discovery-Problem
-# http://learning-0mq-with-pyzmq.readthedocs.org/en/latest/pyzmq/devices/forwarder.html
 
 import zmq
 
@@ -8,13 +7,11 @@ OUT = 'ipc:///tmp/message_flow_out'
 
 context = zmq.Context()
 
-feed_in = context.socket(zmq.SUB)
+feed_in = context.socket(zmq.XSUB)
 feed_in.bind(IN)
-feed_in.setsockopt(zmq.SUBSCRIBE, b'')
 
 feed_out = context.socket(zmq.XPUB)
 feed_out.bind(OUT)
 
 print('[message_proxy] Forwarding messages between {} and {}'.format(IN, OUT))
-dev = zmq.device(zmq.FORWARDER, feed_in, feed_out)
-dev.start()
+zmq.proxy(feed_in, feed_out)


### PR DESCRIPTION
Use either PUB/SUB or XPUB/XSUB, but not one of each. And ZMQ_FORWARDER is deprecated since libzmq3, in favor of zmq_proxy.

This may have been the cause of CPU usage you were seeing, but I'm not sure. It may depend on what version of libzmq/pyzmq you were running. XPUB does receive messages, unlike PUB, and XSUB does send messages, unlike SUB. So it's possible that when a SUB connected to the XPUB, it received a message but the FORWARDER didn't handle it, since the SUB never set POLLOUT. XPUB-XSUB devices allow forwarding subscription messages from downstream subscribers to upstream publishers, so the device's upstream socket doesn't need to specify its own subscription. Since you are subscribing to all, using a PUB-SUB device should work fine as well.

I also removed the link to super-outdated learning-0mq-with-pyzmq docs (not updated since 2012), which can be counterproductive at this point.
